### PR TITLE
Remove comment from pip install command

### DIFF
--- a/lab1_pytorch_intro.ipynb
+++ b/lab1_pytorch_intro.ipynb
@@ -959,7 +959,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install torchviz # `!` signifies a bash operation rather than Python\n",
+    "!pip install torchviz\n",
     "from torchviz import make_dot"
    ]
   },


### PR DESCRIPTION
When using ! in Jupyter, inline comments with # are not stripped before passing to the command so it gets an error if torchviz wasn't installed already